### PR TITLE
Build spark-py, spark-r image as well.

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,9 +1,8 @@
 name: Publish docker image
 
-on: [pull_request]
-#on:
-#  release:
-#    types: [created]
+on:
+  release:
+    types: [created]
 
 jobs:
   publish-release:
@@ -55,7 +54,7 @@ jobs:
       run: |-
         ./bin/docker-image-tool.sh \
         -r opendatastudio \
-        -t test \
+        -t ${{ steps.get_version.outputs.VERSION }} \
         -p kubernetes/dockerfiles/spark/bindings/python/Dockerfile \
         -R kubernetes/dockerfiles/spark/bindings/R/Dockerfile \
         build
@@ -64,6 +63,6 @@ jobs:
       run: |-
         docker images
         echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-        #docker push opendatastudio/spark:${{ steps.get_version.outputs.VERSION }}
-        #docker push opendatastudio/spark-py:${{ steps.get_version.outputs.VERSION }}
-        #docker push opendatastudio/spark-r:${{ steps.get_version.outputs.VERSION }}
+        docker push opendatastudio/spark:${{ steps.get_version.outputs.VERSION }}
+        docker push opendatastudio/spark-py:${{ steps.get_version.outputs.VERSION }}
+        docker push opendatastudio/spark-r:${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,8 +1,9 @@
 name: Publish docker image
 
-on:
-  release:
-    types: [created]
+on: [pull_request]
+#on:
+#  release:
+#    types: [created]
 
 jobs:
   publish-release:

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -43,6 +43,8 @@ jobs:
         sed -i '/^USER/d' resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
         echo 'RUN groupadd --gid $spark_uid spark && useradd -ms /bin/bash spark --uid $spark_uid --gid $spark_uid && chown -R spark:spark /opt/spark/work-dir' >> resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
         echo 'USER ${spark_uid}' >> resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
+        # print
+        cat resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
     - name: Build distribution
       run: |-
         ./dev/make-distribution.sh --name spark --pip --r --tgz -Psparkr -Phadoop-2.7 -Phive -Phive-thriftserver -Pkubernetes

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -50,9 +50,17 @@ jobs:
         DEBCONF_NONINTERACTIVE_SEEN: true
     - name: Build docker image
       run: |-
-        ./bin/docker-image-tool.sh -r opendatastudio -t ${{ steps.get_version.outputs.VERSION }} build
+        ./bin/docker-image-tool.sh \
+        -r opendatastudio \
+        -t test \
+        -p kubernetes/dockerfiles/spark/bindings/python/Dockerfile \
+        -R kubernetes/dockerfiles/spark/bindings/R/Dockerfile \
+        build
+      working-directory: ./dist
     - name: Push image
       run: |-
         docker images
         echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-        docker push opendatastudio/spark:${{ steps.get_version.outputs.VERSION }}
+        #docker push opendatastudio/spark:${{ steps.get_version.outputs.VERSION }}
+        #docker push opendatastudio/spark-py:${{ steps.get_version.outputs.VERSION }}
+        #docker push opendatastudio/spark-r:${{ steps.get_version.outputs.VERSION }}


### PR DESCRIPTION
Tried to build a combined image for scala, python, and R in https://github.com/open-datastudio/spark/pull/2.
However, it requires some trick to build and even [docker bug](https://github.com/moby/moby/issues/37965#issuecomment-426853382) contributes more hacky patches.
This will introduce high maintenance cost, so will just produce a separate image for scala, python and R and let the user select them for now.
